### PR TITLE
fix: add style for answer field

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,3 +17,8 @@ div.rightanswer .wrsUI_app.wrsUI_graph {
     max-width: 800px;
     height: 453px;
 }
+
+div .answer .wrsUI_quizzesAnswerField .wrsUI_mathTypeComponent .wrsUI_inlineMathEditor {
+    display: flex;
+    flex-direction: row;
+}


### PR DESCRIPTION
Here, style has been modified in order to make sure that answer field is appearing correctly (in Moodle Short Answer). 

Check Kanbanize [here](https://wiris.kanbanize.com/ctrl_board/17/cards/33593/details/)