### PR TITLE
fix: add support for additional empty MathML structure in is_empty_mathml function

### DIFF
--- a/question.php
+++ b/question.php
@@ -350,7 +350,8 @@ implements question_automatically_gradable, question_response_answer_comparer {
 
     private function is_empty_mathml(string $mathml) {
         return $mathml == '<math xmlns="http://www.w3.org/1998/Math/MathML"/>'
-            || $mathml == '<math xmlns="http://www.w3.org/1998/Math/MathML"></math>';
+            || $mathml == '<math xmlns="http://www.w3.org/1998/Math/MathML"></math>'
+            || $mathml == '<math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow/><annotation encoding="application/vnd.wiris.mtweb-strokes+json">{"x":[],"y":[],"t":[],"version":"2.0.0"}</annotation></semantics></math>';
     }
 
     public function is_gradable_response(array $response) {


### PR DESCRIPTION

# Card link
Card: [Development card #68995](https://wiris.kanbanize.com/ctrl_board/17/cards/68995)

## What is this PR about?
Enhance the `is_empty_mathml` function to recognize an additional empty MathML structure, improving handling of specific MathML cases.

## Technical reasoning
Added handwritten mathml so it is not recognized as a valid response
